### PR TITLE
Add more rules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,9 @@
-export default /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
+const regex = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
+
+class PackageNameRegExp extends RegExp {
+  constructor() {
+    super(regex)
+  }
+}
+
+export default new PackageNameRegExp()

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const regex = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
+const regex = /^(@[a-z0-9-][a-z0-9-._]*\/)?[a-z0-9-][a-z0-9-._]*$/
 
 class PackageNameRegExp extends RegExp {
   constructor() {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,13 @@ class PackageNameRegExp extends RegExp {
   constructor() {
     super(regex)
   }
+
+  test(string) {
+    if (string.length > 214) {
+      return false
+    }
+    return regex.test(string)
+  }
 }
 
 export default new PackageNameRegExp()

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,14 @@ class PackageNameRegExp extends RegExp {
     super(regex)
   }
 
+  exec(string) {
+    if (string.length > 214) {
+      regex.lastIndex = 0
+      return null
+    }
+    return regex.exec(string)
+  }
+
   test(string) {
     if (string.length > 214) {
       return false

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -20,6 +20,7 @@ export default {
     expect(regex.test('trailing-space ')).toBeFalsy()
     expect(regex.test('s/l/a/s/h/e/s')).toBeFalsy()
     expect(regex.test('CAPITAL-LETTERS')).toBeFalsy()
+    expect(regex.test('with~a~tilde')).toBeFalsy()
     const getStringWithMoreThan214Characters = () => Array(215).fill(1).map(i => i).join('')
     expect(regex.test(getStringWithMoreThan214Characters())).toBeFalsy()
   },

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -21,6 +21,11 @@ export default {
     expect(regex.test('s/l/a/s/h/e/s')).toBeFalsy()
     expect(regex.test('CAPITAL-LETTERS')).toBeFalsy()
     expect(regex.test('with~a~tilde')).toBeFalsy()
+    expect(regex.test('with\'quotes\'')).toBeFalsy()
+    expect(regex.test('with-bangs!!!')).toBeFalsy()
+    expect(regex.test('with-the(char')).toBeFalsy()
+    expect(regex.test('with-the)char')).toBeFalsy()
+    expect(regex.test('with-the*char')).toBeFalsy()
     const getStringWithMoreThan214Characters = () => Array(215).fill(1).map(i => i).join('')
     expect(regex.test(getStringWithMoreThan214Characters())).toBeFalsy()
   },

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,6 +1,16 @@
 import regex from '.'
 
+const getStringWithMoreThan214Characters = () => Array(215).fill(1).map(i => i).join('')
+
 export default {
+  exec: () => {
+    expect(regex.exec('some-package')).toContain('some-package')
+    expect(regex.lastIndex).toEqual(0)
+    expect(regex.exec('crazy!')).toEqual(null)
+    expect(regex.lastIndex).toEqual(0)
+    expect(regex.exec(getStringWithMoreThan214Characters())).toEqual(null)
+    expect(regex.lastIndex).toEqual(0)
+  },
   test: () => {
     // taken from https://github.com/npm/validate-npm-package-name
     expect(regex.test('some-package')).toBeTruthy()
@@ -26,7 +36,6 @@ export default {
     expect(regex.test('with-the(char')).toBeFalsy()
     expect(regex.test('with-the)char')).toBeFalsy()
     expect(regex.test('with-the*char')).toBeFalsy()
-    const getStringWithMoreThan214Characters = () => Array(215).fill(1).map(i => i).join('')
     expect(regex.test(getStringWithMoreThan214Characters())).toBeFalsy()
   },
 }

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -20,5 +20,7 @@ export default {
     expect(regex.test('trailing-space ')).toBeFalsy()
     expect(regex.test('s/l/a/s/h/e/s')).toBeFalsy()
     expect(regex.test('CAPITAL-LETTERS')).toBeFalsy()
+    const getStringWithMoreThan214Characters = () => Array(215).fill(1).map(i => i).join('')
+    expect(regex.test(getStringWithMoreThan214Characters())).toBeFalsy()
   },
 }


### PR DESCRIPTION
Modified the regexp implementation to allow more control and to improve readability. We can always use a standalone regexp, it may be a bad idea if:
  - rules change
  - one wants to add more complicated rules (for instance, the scopes are buggy in the original repo and thus NPM)