### PR TITLE
feat: Add typescript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   "author": "Sebastian Landwehr <info@sebastianlandwehr.com>",
   "type": "module",
   "main": "dist/index.js",
+  "types": "src/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "checkUnknownFiles": "base checkUnknownFiles",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,2 @@
+declare const _default: RegExp;
+export default _default;


### PR DESCRIPTION
Very simple types for the single export from this package - this is just nice in an IDE to know for sure I am importing a valid variable that has the type RegExp.

Also, I noticed that there doesn't really need to be a build step - the `"main"` field could be `src/index.js`, but I couldn't quite work out how the scripts work and didn't want to touch something outside the scope of this PR.
